### PR TITLE
oscore_option_parser kid length calculation error

### DIFF
--- a/modules/oscore/src/oscore2coap.c
+++ b/modules/oscore/src/oscore2coap.c
@@ -110,8 +110,7 @@ oscore_option_parser(struct o_coap_packet *in,
 						out->kid_context.len;
 					temp_kid_len =
 						(uint8_t)(temp_kid_len -
-							  out->kid_context.len +
-							  1);
+							  (out->kid_context.len + 1));
 				}
 
 				/* Get KID */


### PR DESCRIPTION
During this refactoring https://github.com/Fraunhofer-AISEC/uoscore-uedhoc/commit/adb019f474142a267d22d6e0b901947e84cedbce#diff-1c63d304c8681e8854c6a06bc890177df670002c410e4ca5efecae925aebae7cL110 there was an error introduced to how `temp_kid_len` is calculated in `oscore_option_parser ` function

This:
```
temp_kid_len -=
	(out->kid_context.len + 1);
```

was replaced by this:

```
temp_kid_len =
	(uint8_t)(temp_kid_len -
	out->kid_context.len +
	1);
```

which is wrong as `X - Z + 1` is NOT equal to `X - (Z + 1)`
This pull request is addressing it.